### PR TITLE
Initial fixes after testing with React Native.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For the rest-only library:
 var realtime = require('ably').Rest;
 ```
 
-For older versions of react-native, which do not support the `react-native` automatic entrypoint, you may have to instead do
+For older versions of React Native, which do not support the `react-native` automatic entrypoint, you may have to instead do
 
 ```javascript
 var realtime = require('ably/browser/static/ably-reactnative.js').Realtime

--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+import Ably from 'ably';
+
+export default { ...Ably };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "ably-reactnative",
-  "description": "React-native wrapper for the javascript realtime client library for Ably.io, the realtime messaging service",
+  "name": "ably-react-native",
+  "description": "React Native wrapper for the JavaScript realtime client library for Ably.io, the realtime messaging service",
   "version": "0.9.0-beta.2",
   "dependencies": {
     "ably": "~0.9.0-beta.2",
@@ -8,6 +8,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:ably/ably-js-reactnative.git"
+    "url": "git@github.com:ably/ably-js-react-native.git"
   }
 }


### PR DESCRIPTION
* Rename `reactnative` to `react-native`.
* Add index.js.

**Important:** ably-js currently uses `require.resolve` to detect
whether the random bytes dependency is installed. This isn't supported
by React Native, so we need to come up with another way to detect
this —or just let it be.