### PR TITLE
Release 1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ably-react-native",
   "description": "React Native wrapper for the JavaScript realtime client library for Ably.io, the realtime messaging service",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "dependencies": {
     "ably": ">=1.1.25 <=1.2.4",
     "react-native-randombytes": "^3.5.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React Native wrapper for the JavaScript realtime client library for Ably.io, the realtime messaging service",
   "version": "1.1.1",
   "dependencies": {
-    "ably": "^1.1.3",
+    "ably": ">=1.1.25 <=1.2.4",
     "react-native-randombytes": "^3.5.0"
   },
   "repository": {


### PR DESCRIPTION
Resolves issue where ably-js 1.2.5 doesn't work on react-native.